### PR TITLE
Disable zookeeper when running single replica

### DIFF
--- a/charts/stardog/templates/_helpers.tpl
+++ b/charts/stardog/templates/_helpers.tpl
@@ -12,7 +12,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- else -}}
 {{- printf "%s-%s" .Release.Name "stardog" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end -}}}
+{{- end -}}
 
 {{- define "zkservers" -}}
 {{- $zk := dict "servers" (list) -}}

--- a/charts/stardog/templates/_helpers.tpl
+++ b/charts/stardog/templates/_helpers.tpl
@@ -2,6 +2,18 @@
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "stardog.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "stardog" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}}
+
 {{- define "zkservers" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- $namespace := .Release.Namespace -}}

--- a/charts/stardog/templates/_helpers.tpl
+++ b/charts/stardog/templates/_helpers.tpl
@@ -13,5 +13,5 @@
 {{- end -}}
 
 {{- define "imagePullSecret" -}}
-{{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\"} } }" .Values.image.registry .Values.image.username .Values.image.password | b64enc }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.registry (printf "%s:%s" .Values.image.username .Values.image.password | b64enc) | b64enc }}
 {{- end -}}

--- a/charts/stardog/templates/configmap.yaml
+++ b/charts/stardog/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
   {{- (.Files.Glob "files/log4j2.xml").AsConfig | nindent 2 }}
 
   {{- (.Files.Glob "files/stardog.properties").AsConfig | nindent 2 }}
-    pack.enabled=false
+    pack.enabled={{ if (eq (.Values.replicaCount | int) 1) }} false {{ else }} true {{ end }}
     pack.zookeeper.address={{ if .Values.zookeeper.enabled }} {{- template "zkservers" . }} {{ else }} {{ .Values.zookeeper.addresses }} {{ end }}
     pack.node.join.retry.count=15
     pack.node.join.retry.delay=1m

--- a/charts/stardog/templates/configmap.yaml
+++ b/charts/stardog/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
   {{- (.Files.Glob "files/log4j2.xml").AsConfig | nindent 2 }}
 
   {{- (.Files.Glob "files/stardog.properties").AsConfig | nindent 2 }}
-    pack.enabled={{ if (eq (.Values.replicaCount | int) 1) }} false {{ else }} true {{ end }}
+    pack.enabled={{ .Values.cluster.enabled }}
     pack.zookeeper.address={{ if .Values.zookeeper.enabled }} {{- template "zkservers" . }} {{ else }} {{ .Values.zookeeper.addresses }} {{ end }}
     pack.node.join.retry.count=15
     pack.node.join.retry.delay=1m

--- a/charts/stardog/templates/configmap.yaml
+++ b/charts/stardog/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-stardog
+  name: {{ include "stardog.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "stardog.chart" . }}

--- a/charts/stardog/templates/configmap.yaml
+++ b/charts/stardog/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
   {{- (.Files.Glob "files/log4j2.xml").AsConfig | nindent 2 }}
 
   {{- (.Files.Glob "files/stardog.properties").AsConfig | nindent 2 }}
-    pack.enabled=true
+    pack.enabled=false
     pack.zookeeper.address={{ if .Values.zookeeper.enabled }} {{- template "zkservers" . }} {{ else }} {{ .Values.zookeeper.addresses }} {{ end }}
     pack.node.join.retry.count=15
     pack.node.join.retry.delay=1m

--- a/charts/stardog/templates/secret.yaml
+++ b/charts/stardog/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-stardog-password
+  name: {{ include "stardog.fullname" . }}-password
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "stardog.chart" . }}

--- a/charts/stardog/templates/service.yaml
+++ b/charts/stardog/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-stardog
+  name: {{ include "stardog.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Release.Name }}-stardog
+    app: {{ include "stardog.fullname" . }}
     helm.sh/chart: {{ include "stardog.chart" . }}
     app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -20,4 +20,4 @@ spec:
   {{- end }}
   type: LoadBalancer
   selector:
-    app: {{ .Release.Name }}-stardog
+    app: {{ include "stardog.fullname" . }}

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       containers:
       - name: {{ .Release.Name }}-stardog
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
         - containerPort: {{ .Values.ports.server }}
           name: server

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       containers:
       - name: {{ include "stardog.fullname" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
         - containerPort: {{ .Values.ports.server }}
           name: server

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-stardog
+  name: {{ include "stardog.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "stardog.chart" . }}
@@ -13,13 +13,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-stardog
-  serviceName: {{ .Release.Name }}-stardog
+      app: {{ include "stardog.fullname" . }}
+  serviceName: {{ include "stardog.fullname" . }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-stardog
+        app: {{ include "stardog.fullname" . }}
         helm.sh/chart: {{ include "stardog.chart" . }}
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -36,7 +36,7 @@ spec:
               - key: "app"
                 operator: In
                 values:
-                - {{ .Release.Name }}-stardog
+                - {{ include "stardog.fullname" . }}
             topologyKey: "kubernetes.io/hostname"
         {{- else }}
           - weight: 100
@@ -46,7 +46,7 @@ spec:
                 - key: "app"
                   operator: In
                   values:
-                  - {{ .Release.Name }}-stardog
+                  - {{ include "stardog.fullname" . }}
               topologyKey: "kubernetes.io/hostname"
         {{- end }}
       initContainers:
@@ -73,7 +73,7 @@ spec:
           echo "Using existing zookeeper"
         {{ end }}
       containers:
-      - name: {{ .Release.Name }}-stardog
+      - name: {{ include "stardog.fullname" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
@@ -87,12 +87,12 @@ spec:
         - name: stardog-license
           mountPath: /etc/stardog-license
           readOnly: true
-        - name: {{ .Release.Name }}-stardog-password
+        - name: {{ include "stardog.fullname" . }}-password
           mountPath: /etc/stardog-password
           readOnly: true
         - name: data
           mountPath: /var/opt/stardog/
-        - name: {{ .Release.Name }}-stardog-config
+        - name: {{ include "stardog.fullname" . }}-config
           mountPath: /etc/stardog-conf
         env:
         - name: PORT
@@ -148,12 +148,12 @@ spec:
       - name: stardog-license
         secret:
           secretName: stardog-license
-      - name: {{ .Release.Name }}-stardog-config
+      - name: {{ include "stardog.fullname" . }}-config
         configMap:
-          name: {{ .Release.Name }}-stardog
-      - name: {{ .Release.Name }}-stardog-password
+          name: {{ include "stardog.fullname" . }}
+      - name: {{ include "stardog.fullname" . }}-password
         secret:
-          secretName: {{ .Release.Name }}-stardog-password
+          secretName: {{ include "stardog.fullname" . }}-password
           items:
             - key: password
               path: adminpw

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -25,6 +25,9 @@ admin:
 image:
   registry: https://registry.hub.docker.com/v1/repositories
   repository: stardog/stardog
+# Alternative config to pull from Stardog private repository
+  # registry: stardog-eps-docker.jfrog.io
+  # repository: stardog-eps-docker.jfrog.io/stardog
   tag: latest
   pullPolicy: IfNotPresent
   # username:

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -2,6 +2,10 @@
 # The number of Stardog replicas to deploy in the cluster
 replicaCount: 3
 
+cluster:
+  # Start Stardog as a cluster
+  enabled: true
+
 # The number of seconds to wait for pods to shutdown before
 # killing them forcefully
 terminationGracePeriodSeconds: 300

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -72,7 +72,7 @@ function helm_install_stardog_cluster_with_zookeeper() {
 }
 
 function helm_install_single_node_stardog() {
-	echo "Installing Stardog Cluster"
+	echo "Installing single node Stardog"
 
 	echo "Running helm install for ${HELM_RELEASE_NAME}"
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -95,7 +95,7 @@ function helm_install_single_node_stardog() {
 		exit ${rc}
 	fi
 
-	echo "Stardog Cluster installed."
+	echo "Single node Stardog installed."
 }
 
 function check_helm_release_exists() {
@@ -175,18 +175,18 @@ function create_and_drop_db() {
 	echo "Successfully dropped database."
 }
 
-function helm_delete_stardog_cluster() {
-	echo "Deleting Stardog Cluster"
+function helm_delete_stardog_release() {
+	echo "Deleting Stardog release"
 
 	helm delete ${HELM_RELEASE_NAME} --namespace ${NAMESPACE}
 	rc=$?
 
 	if [ ${rc} -ne 0 ]; then
-		echo "Helm failed to delete Stardog Cluster, exiting"
+		echo "Helm failed to delete Stardog release, exiting"
 		exit ${rc}
 	fi
 
-	echo "Stardog Cluster deleted."
+	echo "Stardog release deleted."
 }
 
 echo "Starting the Helm smoke tests"
@@ -204,7 +204,7 @@ set_stardog_ip
 create_and_drop_db
 
 echo "Cleaning up Helm deployment"
-helm_delete_stardog_cluster
+helm_delete_stardog_release
 check_helm_release_deleted
 
 echo "Test: single node Stardog without ZooKeeper"
@@ -214,7 +214,7 @@ check_expected_num_stardog_pods 1
 check_expected_num_zk_pods 0
 
 echo "Cleaning up Helm deployment"
-helm_delete_stardog_cluster
+helm_delete_stardog_release
 check_helm_release_deleted
 
 echo "Helm smoke tests completed."


### PR DESCRIPTION
1. Disabled zookeeper pack when running a single replica (Zookeeper not required).
2. Updated imagePullSecret template to include registry to allow it to pull from a private repository 
3. Added fullname template to allow user to override kubernetes resource names with fullnameOverride