### PR TITLE
Support non-root container

### DIFF
--- a/charts/stardog/files/log4j2.xml
+++ b/charts/stardog/files/log4j2.xml
@@ -24,7 +24,7 @@
 		<File name="zookeeperAppender"
 			  fileName="${LOG_DIR}/${ZOOKEEPER_LOG}.log">
 			<PatternLayout pattern="${PATTERN}"/>
-		</File>
+		</File> 
 	</Appenders>
 	<Loggers>
 		<Root level="WARN">
@@ -47,7 +47,7 @@
 		<!-- redirect all zookeeper records to its own log file -->
 		<Logger name="org.apache.zookeeper" level="INFO" additivity="false">
 			<AppenderRef ref="STDOUT"/>
-			<AppenderRef ref="zookeeperAppender"/>
+			<AppenderRef ref="zookeeperAppender"/> 
 		</Logger>
 
 		<!-- do not edit -->

--- a/charts/stardog/templates/configmap.yaml
+++ b/charts/stardog/templates/configmap.yaml
@@ -1,7 +1,23 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "stardog.fullname" . }}
+  name: {{ include "stardog.fullname" . }}-log4j
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "stardog.chart" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+data:{{ if .Values.log4jConfig.override }}
+  log4j2.xml: {{ toJson .Values.log4jConfig.content }}{{ else }}
+  {{- (.Files.Glob "files/log4j2.xml").AsConfig | nindent 2 }}
+{{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stardog.fullname" . }}-properties
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "stardog.chart" . }}
@@ -11,8 +27,6 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 
 data:
-  {{- (.Files.Glob "files/log4j2.xml").AsConfig | nindent 2 }}
-
   {{- (.Files.Glob "files/stardog.properties").AsConfig | nindent 2 }}
     pack.enabled={{ .Values.cluster.enabled }}
     pack.zookeeper.address={{ if .Values.zookeeper.enabled }} {{- template "zkservers" . }} {{ else }} {{ .Values.zookeeper.addresses }} {{ end }}

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -27,6 +27,12 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
         app.kubernetes.io/component: server
     spec:
+{{ if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup  }}
+{{ end }}
       affinity:
         podAntiAffinity:
           {{ .Values.antiAffinity }}:
@@ -49,6 +55,7 @@ spec:
                   - {{ include "stardog.fullname" . }}
               topologyKey: "kubernetes.io/hostname"
         {{- end }}
+{{ if .Values.cluster.enabled }}
       initContainers:
       - name: wait-for-zk
         image: busybox
@@ -72,6 +79,7 @@ spec:
         {{ else }}
           echo "Using existing zookeeper"
         {{ end }}
+{{ end }}
       containers:
       - name: {{ include "stardog.fullname" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -92,8 +100,13 @@ spec:
           readOnly: true
         - name: data
           mountPath: /var/opt/stardog/
-        - name: {{ include "stardog.fullname" . }}-config
-          mountPath: /etc/stardog-conf
+          readOnly: false
+        - name: {{ include "stardog.fullname" . }}-properties-vol
+          mountPath: /etc/stardog-conf/stardog.properties
+          subPath: stardog.properties
+        - name: {{ include "stardog.fullname" . }}-log4j-vol
+          mountPath: /var/opt/stardog/log4j2.xml
+          subPath: log4j2.xml
         env:
         - name: PORT
           value: "{{ .Values.ports.server }}"
@@ -113,7 +126,6 @@ spec:
         - |
           set -ex
           {{ .Files.Get "files/utils.sh" | indent 10 }}
-          cp /etc/stardog-conf/log4j2.xml ${STARDOG_HOME}/log4j2.xml
           /opt/stardog/bin/stardog-admin server start --foreground --port ${PORT} --home ${STARDOG_HOME}
         livenessProbe:
           httpGet:
@@ -144,24 +156,33 @@ spec:
       - name: stardog-license
         secret:
           secretName: stardog-license
-      - name: {{ include "stardog.fullname" . }}-config
+      - name: {{ include "stardog.fullname" . }}-properties-vol
         configMap:
-          name: {{ include "stardog.fullname" . }}
+          name: {{ include "stardog.fullname" . }}-properties
+          items:
+          - key: stardog.properties
+            path: stardog.properties
+      - name: {{ include "stardog.fullname" . }}-log4j-vol
+        configMap:
+          name: {{ include "stardog.fullname" . }}-log4j
+          items: 
+          - key: log4j2.xml
+            path: log4j2.xml
       - name: {{ include "stardog.fullname" . }}-password
         secret:
           secretName: {{ include "stardog.fullname" . }}-password
           items:
             - key: password
               path: adminpw
-              mode: 400
+              mode: 444
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
   volumeClaimTemplates:
   - metadata:
       name: data
     spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.persistence.storageClass }}
+      accessModes: [ "ReadWriteOnce" ]{{ if .Values.persistence.storageClass }}
+      storageClassName: {{ .Values.persistence.storageClass }}{{ end }}
       resources:
         requests:
           storage: {{ .Values.persistence.size }}

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -53,6 +53,20 @@ resources: {}
 #    cpu: 2
 #    memory: 6Gi
 
+
+# these allow you to configure the UID and group ID used by the container when it's running, and the fsGroup sets the group id for the volume-mounts
+# if enabled: false, then the whole block is skipped
+securityContext:
+  enabled: false
+  runAsUser: null
+  runAsGroup: null
+  fsGroup: null
+
+log4jConfig:
+  override: false
+  # we provide a default log4j2.xml, if you want to provide your own. in your own values.yaml, set log4Config.override: true, and log4Config.content
+  # content: null
+
 # Settings to use for the ZooKeeper chart that Stardog depends on.
 # Stardog requires ZooKeeper 3.4.x.
 zookeeper:


### PR DESCRIPTION
This builds on top of @johnplacek 's earlier PR. 
intent is to 
a) enable nonroot container
b) avoid shipping busybox (end-client has a strict list of containers they let into their repo. the fewer the better)

on a)
* split the configmap into two so we can put them where they need to be, with the cp on container start. 
* have included the Dockerfile with the perm change we needed to `/var/opt/stardog`
