### PR TITLE
Add values parameters for K8S Stardog probes

### DIFF
--- a/charts/stardog/files/utils.sh
+++ b/charts/stardog/files/utils.sh
@@ -9,7 +9,7 @@ function wait_for_start {
     set +e
     while [[ ${RC} -ne 0 ]];
     do
-      if [[ ${COUNT} -gt 300 ]]; then
+      if [[ ${COUNT} -gt 600 ]]; then
           return 1;
       fi
       COUNT=$(expr 1 + ${COUNT} )
@@ -18,7 +18,7 @@ function wait_for_start {
       RC=$?
     done
     # Give it a second to finish starting up
-    sleep 5
+    sleep 20
 
     return 0
     )

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -131,16 +131,16 @@ spec:
           httpGet:
             path: /admin/alive
             port: server
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          timeoutSeconds: 15
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
             path: /admin/healthcheck
             port: server
-          initialDelaySeconds: 90
-          periodSeconds: 5
-          timeoutSeconds: 3
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         lifecycle:
           preStop:
             exec:

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -67,6 +67,21 @@ log4jConfig:
   # we provide a default log4j2.xml, if you want to provide your own. in your own values.yaml, set log4Config.override: true, and log4Config.content
   # content: null
 
+# Stardog liveness probe settings. Consider increasing initialDelaySeconds on clouds where
+# storage provisioning is slower. It is not generally required to modify periodSeconds and timeoutSeconds.
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 15
+
+# Stardog readiness probe settings. Consider increasing initialDelaySeconds when using nodes with
+# K8S nodes with limited CPUs. It is not generally required to modify periodSeconds and timeoutSeconds.
+readinessProbe:
+  initialDelaySeconds: 90
+  periodSeconds: 5
+  timeoutSeconds: 3
+
+
 # Settings to use for the ZooKeeper chart that Stardog depends on.
 # Stardog requires ZooKeeper 3.4.x.
 zookeeper:


### PR DESCRIPTION
Add values parameters for K8S liveness and readiness probes. This can be
useful when running on different clouds where the time to provision may
vary. The previous settings are maintained as defaults. Also increase
the time that the post-install admin password setting waits for Stardog
to become available. Fixes #19. 