### PR TITLE
Allow user to set annotations and loadBalancerIP property of service

### DIFF
--- a/charts/stardog/templates/service.yaml
+++ b/charts/stardog/templates/service.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: {{ .Values.ports.server }}
@@ -19,5 +23,8 @@ spec:
     name: sql
   {{- end }}
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   selector:
     app: {{ include "stardog.fullname" . }}

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -29,6 +29,8 @@ javaArgs: "-Xmx2g -Xms2g -XX:MaxDirectMemorySize=1g"
 # The service type to use for Stardog ports
 service:
   type: LoadBalancer
+  annotations: {}
+  # loadBalancerIP: 0.0.0.0
 
 # The server port is the port to expose the Stardog server
 # The sql port is the port to expose Stardog's business intelligence server


### PR DESCRIPTION
No issue for this change.

In order to set a DNS label on the load balancer in the azure environment I need to be able to set service annotations
To support a public IP address for the load balancer in the Azure environment I need to be able to set the loadBalancerIP property.