### PR TITLE
Remove password for post-install job (fixes #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 2.0.3 (Unreleased)
+
+* Remove admin password from post-install job standard out (#48)
+
 # 2.0.2 (2021-06-09)
 
 Features:

--- a/charts/stardog/files/utils.sh
+++ b/charts/stardog/files/utils.sh
@@ -25,9 +25,11 @@ function wait_for_start {
 
 function change_pw {
     (
-    set +e
+    set +ex
     HOST=${1}
     PORT=${2}
+
+    echo "/opt/stardog/bin/stardog-admin --server http://${HOST}:${PORT} user passwd -N xxxxxxxxxxxxxx"
     NEW_PW=$(cat /etc/stardog-password/adminpw)
     /opt/stardog/bin/stardog-admin --server http://${HOST}:${PORT} user passwd -N ${NEW_PW}
     if [[ $? -eq 0 ]];


### PR DESCRIPTION
The post-install job sets the admin password for Stardog. It was being
inadvertatly echoed to the the container standard out because set -x was
enabled.