### PR TITLE
Provide helm values for the busybox image (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
+# Unreleased
 
+* Provide parameters for setting the origin of the busybox image which is used
+  as a part of the Stardog pod initialization (#60)
+  
 # 2.0.3 (2021-09-16)
 
 * Use Java G1 gc by default (#56)

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -31,7 +31,8 @@ Configuration Parameters
 | `admin.password`                             | Stardog admin password |
 | `javaArgs`                                   | Java args for Stardog server |
 | `image.registry`                             | The Docker registry containing the Stardog image |
-| `image.repository`                           | The Docker image repostory containing the Stardog image  |
+| `image.repository`                           | The Docker image repository containing the Stardog image  |
+| `image.pullPolicy`                           | The Docker image pullPolicy for Stardog |
 | `image.tag`                                  | The Docker image tag for Stardog |
 | `image.username`                             | The Docker registry username |
 | `image.password`                             | The Docker registry password |
@@ -45,6 +46,12 @@ Configuration Parameters
 | `securityContext.runAsUser`                  | UID used by the Stardog container to run as non-root |
 | `securityContext.runAsGroup`                 | GID used by the Stardog container to run as non-root |
 | `securityContext.fsGroup`                    | GID for the volume mounts |
+| `busybox.image.registry`                     | The Docker registry containing the busybox image (used as a part of Stardog initialization) |
+| `busybox.image.repository`                   | The Docker image repository containing the busybox image (used as a part of Stardog initialization) |
+| `busybox.image.pullPolicy`                   | The Docker image pullPolicy for the busybox image (used as a part of Stardog initialization) |
+| `busybox.image.tag`                          | The Docker image tag for busybox image (used as a part of Stardog initialization) |
+| `busybox.image.username`                     | The Docker registry username for busybox image registry (used as a part of Stardog initialization) |
+| `busybox.image.password`                     | The Docker registry password for the busybox image registry (used as a part of Stardog initialization)  |
 
 The default values are specified in `values.yaml` as well as the required values for the ZooKeeper chart.
 

--- a/charts/stardog/templates/_helpers.tpl
+++ b/charts/stardog/templates/_helpers.tpl
@@ -28,6 +28,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.registry (printf "%s:%s" .Values.image.username .Values.image.password | b64enc) | b64enc }}
 {{- end -}}
 
+{{- define "imagePullSecretBusybox" -}}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.busybox.image.registry (printf "%s:%s" .Values.busybox.image.username .Values.busybox.image.password | b64enc) | b64enc }}
+{{- end -}}
+
 {{/*
 Return Stardog namespace to use
 */}}

--- a/charts/stardog/templates/secret-image-busybox.yaml
+++ b/charts/stardog/templates/secret-image-busybox.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.busybox.image.username .Values.busybox.image.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-image-busybox-pull-secret
+  namespace: {{ include "stardog.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "stardog.chart" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecretBusybox" .  }}
+{{- end }}

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -62,7 +62,8 @@ spec:
 {{ if .Values.cluster.enabled }}
       initContainers:
       - name: wait-for-zk
-        image: busybox
+        image: {{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}
+        imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
         command:
         - /bin/sh
         - -c
@@ -158,6 +159,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-image-pull-secret
+      - name: {{ .Release.Name }}-image-busybox-pull-secret
       volumes:
       - name: stardog-license
         secret:

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -110,6 +110,16 @@ readinessProbe:
   periodSeconds: 5
   timeoutSeconds: 3
 
+# The busybox image is used as light weight init container as a part of
+# stardog initialization.
+busybox:
+  image:
+    registry: https://registry.hub.docker.com/v1/repositories
+    repository: busybox
+    tag: stable
+    pullPolicy: IfNotPresent
+    # username:
+    # password:
 
 # Settings to use for the ZooKeeper chart that Stardog depends on.
 # The full set of options can be found on the bitname ZK chart:
@@ -148,3 +158,4 @@ zookeeper:
 #    failureThreshold: 6
 #    successThreshold: 1
 #    probeCommandTimeout: 2
+


### PR DESCRIPTION
Allow the busybox image used for the Stardog pod init container to be
sourced from a place other then dockerhub.