### PR TITLE
Create tmpDir if it doesn't already exist (Fix #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 * Provide parameters for setting the origin of the busybox image which is used
   as a part of the Stardog pod initialization (#60)
-  
+* Create the tmpDir used by Stardog if it doesn't already exist. This can be useful when
+  placing the tmpDir onto the same volume as STARDOG_HOME (/var/opt/stardog). Note 
+  that it's critical not to choose a path within STARDOG_HOME that could conflict with a
+  database name. See the [values.yaml](charts/stardog/values.yaml) for details. (#62)
+
 # 2.0.3 (2021-09-16)
 
 * Use Java G1 gc by default (#56)

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -40,7 +40,7 @@ Configuration Parameters
 | `persistence.size`                           | The size of volume for Stardog home |
 | `ports.server`                               | The port to expose Stardog server |
 | `ports.sql`                                  | The port to expose Stardog BI server |
-| `tmpDir`                                     | The directory to use for Stardog tmp space |
+| `tmpDir`                                     | The directory to use for Stardog tmp space. If you choose to place this in STARDOG_HOME (/var/opt/stardog) for performance reasons, ensure that it does not conflict with any possible database names. For example, a good choice might be /var/opt/stardog/tmp-4646E7B662A7. If the directory does not exist it will be created. |
 | `log4jConfig.override`                       | Whether to override the default log4j config |
 | `log4jConfig.content`                        | The new log4j configuration |
 | `securityContext.runAsUser`                  | UID used by the Stardog container to run as non-root |

--- a/charts/stardog/files/utils.sh
+++ b/charts/stardog/files/utils.sh
@@ -54,3 +54,18 @@ function change_pw {
     fi
     )
 }
+
+function make_temp {
+    (
+    set +e
+    TEMP_PATH=${1}
+
+    if [ ! -d "$TEMP_PATH" ]; then
+      mkdir -p $TEMP_PATH
+      if [ $? -ne 0 ]; then
+        echo "Could not create stardog tmp directory ${TEMP_PATH}" >&2
+        return 1
+      fi
+    fi
+    )
+}

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -125,6 +125,8 @@ spec:
           value: "-XX:ActiveProcessorCount={{ .Values.resources.requests.cpu }}  -Djava.io.tmpdir={{ .Values.tmpDir }} {{ .Values.javaArgs }}"
         - name: STARDOG_PERF_JAVA_ARGS
           value: "{{ .Values.stardogPerfJavaArgs }}"
+        - name: STARDOG_TMP_PATH
+          value: "{{ .Values.tmpDir }}"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         command:
@@ -133,6 +135,7 @@ spec:
         - |
           set -ex
           {{ .Files.Get "files/utils.sh" | indent 10 }}
+          make_temp ${STARDOG_TMP_PATH}
           /opt/stardog/bin/stardog-admin server start --foreground --port ${PORT} --home ${STARDOG_HOME}
         livenessProbe:
           httpGet:

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -41,7 +41,11 @@ ports:
   server: 5820
   # sql: 5806
 
-# The location Stardog will use for temporary space (i.e. java.io.tmpdir)
+# The location Stardog will use for temporary space (i.e. java.io.tmpdir).
+# If you choose to place this in STARDOG_HOME (/var/opt/stardog) for performance
+# reasons, ensure that it does not conflict with any possible database names.
+# For example, a good choice might be /var/opt/stardog/tmp-4646E7B662A7.
+# If the directory does not exist it will be created.
 tmpDir: /tmp
 
 # The initial password for the Stardog admin user


### PR DESCRIPTION
If the values file parameter tmpDir does not already exist on disk
create it in the init container before starting Stardog.