### PR TITLE
Make imagePullSecrets optional

### DIFF
--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -162,9 +162,17 @@ spec:
               - |
                 /opt/stardog/bin/stardog-admin server stop -u admin -p $(cat /etc/stardog-password/adminpw)
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- if or (and .Values.image.username .Values.image.password) (and .Values.busybox.image.username .Values.busybox.image.password) }}
       imagePullSecrets:
+{{- if and .Values.image.username .Values.image.password }}
       - name: {{ .Release.Name }}-image-pull-secret
+{{- end}}
+{{- if and .Values.busybox.image.username .Values.busybox.image.password }}
       - name: {{ .Release.Name }}-image-busybox-pull-secret
+{{- end}}
+{{- else }}
+      imagePullSecrets: null
+{{- end}}
       volumes:
       - name: stardog-license
         secret:

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -249,11 +249,11 @@ function validate_helm_chart() {
 }
 
 echo "Starting the Helm smoke tests"
+validate_helm_chart
 dependency_checks
 minikube_start_tunnel
 install_stardog
 helm_setup_cluster
-validate_helm_chart
 
 echo "Test: Stardog 3 node cluster with ZooKeeper"
 helm_install_stardog_cluster_with_zookeeper

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -242,11 +242,18 @@ function helm_delete_stardog_release() {
 	echo "Stardog release deleted."
 }
 
+function validate_helm_chart() {
+	echo "Validating the helm chart"
+	helm lint charts/stardog >/dev/null 2>&1 || { echo >&2 "The helm chart is not valid, exiting."; exit 1; }
+	echo "Helm chart valid."
+}
+
 echo "Starting the Helm smoke tests"
 dependency_checks
 minikube_start_tunnel
 install_stardog
 helm_setup_cluster
+validate_helm_chart
 
 echo "Test: Stardog 3 node cluster with ZooKeeper"
 helm_install_stardog_cluster_with_zookeeper


### PR DESCRIPTION
Make imagePullSecrets optional, in order to make both the busybox and main stardog image pull secrets optional and avoid excessive errors in `journalctl` cmd. 

```
Jul 18 09:07:52 re-1.relocal k3s[3559]: I0718 09:07:52.913214    3559 kubelet_pods.go:891] "Unable to retrieve pull secret, the image pull may not succeed." pod="re-graph/richard-stardog-0" secret="" err="secret \"richard-image-pull-secret\" not found"
Jul 18 09:07:52 re-1.relocal k3s[3559]: I0718 09:07:52.913337    3559 kubelet_pods.go:891] "Unable to retrieve pull secret, the image pull may not succeed." pod="re-graph/richard-stardog-0" secret="" err="secret \"richard-image-busybox-pull-secret\" not found"
```

Possibly the whole `imagePullSecrets` needs to be inside an if statement too? But helm linting didn't throw any errors with the below change.

*Testing*
Currently only tested with helm lint.