### PR TITLE
Add comments relating memory sizing.

### DIFF
--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -57,6 +57,28 @@ Configuration Parameters
 
 The default values are specified in `values.yaml` as well as the required values for the ZooKeeper chart.
 
+Memory Parameters
+-----------------
+
+Memory settings are part of both javaArgs and resources within
+values.yaml.  The settings must be coordinated.
+
+Stardog will aggressive use all memory allocated to it via the
+javaArgs settings of -Xmx and -XX:MaxDirectMemorySize.  The total
+memory used by Stardog is the sum of -Xmx and -XX:MaxDirectMemorySize.
+
+The resources settings of requests:memory and optional limits:memory
+must account for the javaArgs settings.  requests:memory should be at
+least 1g larger than -Xms and -XX:MaxDirectMemorySize total. 2g larger is
+preferred.  If you chose to establish resourse:limits, limits:memory
+must be at least 1g larger than -Xmx and -XX:MaxDirectMemorySize total.  A
+too small limits:memory setting will likely result in a system crash.
+
+Network based disk storage is not recommended.  If used, the
+limits:memory should be at least 4g larger than -Xmx and
+-XX:MaxDirectMemorySize total.  Network storage often caches large
+writes related to data loads and db optimizations.
+
 Upgrades
 --------
 

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -53,7 +53,7 @@ Configuration Parameters
 | `busybox.image.tag`                          | The Docker image tag for busybox image (used as a part of Stardog initialization) |
 | `busybox.image.username`                     | The Docker registry username for busybox image registry (used as a part of Stardog initialization) |
 | `busybox.image.password`                     | The Docker registry password for the busybox image registry (used as a part of Stardog initialization)  |
-| `additionalStardogProperties`                | Allow adding additional settings to stardog.properties file |
+| `additionalStardogProperties`                | Allows adding additional settings to stardog.properties file |
 
 The default values are specified in `values.yaml` as well as the required values for the ZooKeeper chart.
 
@@ -74,10 +74,23 @@ preferred.  If you chose to establish resourse:limits, limits:memory
 must be at least 1g larger than -Xmx and -XX:MaxDirectMemorySize total.  A
 too small limits:memory setting will likely result in a system crash.
 
-Network based disk storage is not recommended.  If used, the
-limits:memory should be at least 4g larger than -Xmx and
--XX:MaxDirectMemorySize total.  Network storage often caches large
-writes related to data loads and db optimizations.
+Network based disk storage
+--------------------------
+
+Network based disk storage is not recommended.  This include NFS, SMB, and
+EFS based storage systems.
+
+If network based disk is used, the following should be part of the
+additionalStardogProperties setting:
+
+storage.envoptions.use_mmap_writes = false
+
+Stardog uses a technique call memory mapping for high speed writes of
+new data and data optimizations.  Memory mapping is not appropriate
+for network files systems.  Memory mapping is simulated at the server
+causing increased operating system memory usage, slower write
+throughput, and increased chance of error / data corruption.  The
+above setting disables the use of memory mapping.
 
 Upgrades
 --------

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -77,8 +77,10 @@ too small limits:memory setting will likely result in a system crash.
 Network based disk storage
 --------------------------
 
-Network based disk storage is not recommended.  This include NFS, SMB, and
-EFS based storage systems.
+Network based disk storage is not recommended.  This include NFS, SMB,
+and EFS based storage systems.  Stardog instead recommends setting the
+storageClass to gp2 on AWS and leaving the default values of standard
+for Azure and GCP.
 
 If network based disk is used, the following should be part of the
 additionalStardogProperties setting:

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -63,7 +63,7 @@ Memory Parameters
 Memory settings are part of both javaArgs and resources within
 values.yaml.  The settings must be coordinated.
 
-Stardog will aggressive use all memory allocated to it via the
+Stardog will aggressively use all memory allocated to it via the
 javaArgs settings of -Xmx and -XX:MaxDirectMemorySize.  The total
 memory used by Stardog is the sum of -Xmx and -XX:MaxDirectMemorySize.
 

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -24,6 +24,8 @@ cluster:
 terminationGracePeriodSeconds: 300
 
 # Java args for Stardog server
+#  Shown are memory sizing parameters.  Total potential memory is sum of
+#  -Xmx and -XX:MaxDirectMemorySize.  In this sample, the total memory is 3g
 javaArgs: "-Xmx2g -Xms2g -XX:MaxDirectMemorySize=1g"
 
 # Additional arguments passed to Stardog at server start
@@ -81,6 +83,8 @@ antiAffinity: requiredDuringSchedulingIgnoredDuringExecution
 
 # Stardog should have at least 2 CPUs. The CPU request value is used to set
 # -XX:ActiveProcessorCount=N for the JVM.
+# If limits:memory is activated, it must be at least 1g larger than the
+#   total of javaArg's -Xmx and -XX:MaxDirectMemorySize.  2g larger is recommended.
 resources:
   requests:
     cpu: 2


### PR DESCRIPTION
Adding comments about memory sizing in README.md and values.yaml.  

These changes were part of the discussions to correct a customer issue in PLAT-5010.  (Not naming customer since this is a public repo.)