### PR TITLE
Ignores image pull secret if not passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,39 @@ Deleting
 ```
 $ helm delete <helm-release-name> --namespace <your-namespace>
 ```
+
+Running the tests locally
+-------------------------
+
+This assume you have Docker installed and running this on MacOs. For other systems, install their corresponding binaries.
+
+## Install minikube
+```
+# Get the one from here https://github.com/kubernetes/minikube/releases For macos, this is the latest version
+curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/<minikube-version>/minikube-darwin-arm64
+chmod +x minikube
+sudo mv minikube /usr/local/bin/
+```
+
+## Start minikube
+Your k8s version should be the same as your kubectl version. This will update you ~/.kube/config file and set minikube to the current context.
+```
+minikube start --driver=docker --kubernetes-version=v.1.29.0
+```
+
+## Set up the Stardog license
+Make sure you have a proper stardog license called `stardog-license-key.bin` located in the root directory of this project.
+```
+kubectl create secret generic stardog-license --from-file stardog-license-key.bin=stardog-license-key.bin
+```
+
+## Install Stardog as a helm release
+```
+helm install stardog charts/stardog/ --wait --timeout 15m -f tests/minikube.yaml \
+ --set "cluster.enabled=false" \
+--set "replicaCount=1" \
+--set "zookeeper.enabled=false"
+```
+
+## Run the tests
+ ./tests/smoke.sh

--- a/charts/stardog/templates/post-install-job.yaml
+++ b/charts/stardog/templates/post-install-job.yaml
@@ -52,8 +52,10 @@ spec:
           {{ .Files.Get "files/utils.sh" | indent 10 }}
           wait_for_start ${HOST} ${PORT} ${DELAY}
           change_pw ${HOST} ${PORT}
+      {{- if and .Values.image.username .Values.image.password }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-image-pull-secret
+      {{- end}}
       volumes:
       - name: {{ include "stardog.fullname" . }}-password
         secret:

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -164,14 +164,12 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- if or (and .Values.image.username .Values.image.password) (and .Values.busybox.image.username .Values.busybox.image.password) }}
       imagePullSecrets:
-{{- if and .Values.image.username .Values.image.password }}
+  {{- if and .Values.image.username .Values.image.password }}
       - name: {{ .Release.Name }}-image-pull-secret
-{{- end}}
-{{- if and .Values.busybox.image.username .Values.busybox.image.password }}
+  {{- end}}
+  {{- if and .Values.busybox.image.username .Values.busybox.image.password }}
       - name: {{ .Release.Name }}-image-busybox-pull-secret
-{{- end}}
-{{- else }}
-      imagePullSecrets: null
+  {{- end}}
 {{- end}}
       volumes:
       - name: stardog-license

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -228,6 +228,17 @@ function drop_db() {
 	echo "Successfully dropped database."
 }
 
+function image_pull_secret_should_not_be_set_by_default() {
+	statefulset_name=$(kubectl -n ${NAMESPACE} get sts --no-headers | grep stardog | awk '{print $1}')
+	command_output=$(kubectl -n ${NAMESPACE} get sts -o yaml ${statefulset_name}) &&  echo ${command_output} | grep imagePullSecret
+	rc=$?
+	if [ ${rc} -ne 1 ]; then
+		echo "imagePullSecret option was set, but should not be set on default settings."
+		exit ${rc}
+	fi
+	echo "Success: imagePullSecret should not be set by default"
+}
+
 function helm_delete_stardog_release() {
 	echo "Deleting Stardog release"
 
@@ -265,6 +276,9 @@ download_db_data
 create_db
 query_db
 drop_db
+
+echo "Testing chart configurations"
+image_pull_secret_should_not_be_set_by_default
 
 echo "Cleaning up Helm deployment"
 helm_delete_stardog_release


### PR DESCRIPTION
This gets rid of completetly setting the option of imagePullSecret when we don't pass any image credentials. right now it's being set to null, and it's setting the `imagePullSecret: null` but it could be that journalctl also picks that up and logs it as an error.
* adds a simple test to make sure that no imagePullSecret should be set if no creds are passed
* adds the check for the post-install job as well.
* adds readme to run tests locally