### PR TITLE
added option to add a passwordSecretRef for the database setup

### DIFF
--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -29,6 +29,7 @@ Configuration Parameters
 | `replicaCount`                               | The number of replicas in Stardog Cluster |
 | `podManagementPolicy`                        | Set the pod startup policy - use `OrderedReady` (default) or `Parallel` |
 | `admin.password`                             | Stardog admin password |
+| `admin.passwordSecretRef`                    | A reference to an external Stardog admin password secret |
 | `javaArgs`                                   | Java args for Stardog server |
 | `serverStartArgs`                            | Additional arguments for Stardog server start |
 | `image.registry`                             | The Docker registry containing the Stardog image |

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -29,7 +29,7 @@ Configuration Parameters
 | `replicaCount`                               | The number of replicas in Stardog Cluster |
 | `podManagementPolicy`                        | Set the pod startup policy - use `OrderedReady` (default) or `Parallel` |
 | `admin.password`                             | Stardog admin password |
-| `admin.passwordSecretRef`                    | A reference to an external Stardog admin password secret |
+| `admin.passwordSecretRef`                    | A reference to an external Stardog admin password secret (if set, `admin.password` will be ignored) |
 | `javaArgs`                                   | Java args for Stardog server |
 | `serverStartArgs`                            | Additional arguments for Stardog server start |
 | `image.registry`                             | The Docker registry containing the Stardog image |

--- a/charts/stardog/templates/post-install-job.yaml
+++ b/charts/stardog/templates/post-install-job.yaml
@@ -59,7 +59,11 @@ spec:
       volumes:
       - name: {{ include "stardog.fullname" . }}-password
         secret:
+{{- if .Values.admin.passwordSecretRef }}
+          secretName: {{ .Values.admin.passwordSecretRef }}
+{{ else }}
           secretName: {{ include "stardog.fullname" . }}-password
+{{- end}}
           items:
             - key: password
               path: adminpw

--- a/charts/stardog/templates/secret.yaml
+++ b/charts/stardog/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if (not .Values.admin.passwordSecretRef) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ metadata:
 type: Opaque
 data:
   password: {{ b64enc .Values.admin.password }}
+{{- end }}

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -189,7 +189,11 @@ spec:
             path: log4j2.xml
       - name: {{ include "stardog.fullname" . }}-password
         secret:
+{{- if .Values.admin.passwordSecretRef }}
+          secretName: {{ .Values.admin.passwordSecretRef }}
+{{ else }}
           secretName: {{ include "stardog.fullname" . }}-password
+{{- end}}
           items:
             - key: password
               path: adminpw

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -54,6 +54,7 @@ tmpDir: /tmp
 # The initial password for the Stardog admin user
 admin:
   password: admin
+  # passwordSecretRef: password-secret
 
 image:
   registry: https://registry.hub.docker.com/v2/repositories


### PR DESCRIPTION
Added a new configuration option **admin.passwordSecretRef** 

The option allows to reference a external secret for the Database password instead of the integrated chart secret.
This allows easier integration with Cloud secret services like AWS Secret Manager.

Implementation is very simple - if the **admin.passwordSecretRef** is set, the **admin.password** will be ignored. Meaning, the helm chart does not create a secret and it is replaced by the external secret.