### PR TITLE
Update CircleCI ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
    build:
      machine:
-       image: ubuntu-2004:202201-02
+       image: ubuntu-2204:2024.05.1
 
      environment:
        K8S_VERSION: 1.21.14


### PR DESCRIPTION
Current ubuntu image is being EOL'd by Circle on 2024-09-30, updating to a newer one.