### PR TITLE
[CLOUD-2628] Add Launchpad v3.0 helm chart; update Stardog helm chart

### DIFF
--- a/charts/launchpad/Chart.yaml
+++ b/charts/launchpad/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: launchpad
+description: Helm chart to deploy Launchpad
+version: 0.1.0
+appVersion: 3.0.1
+home: https://github.com/stardog-union/helm-charts
+icon: https://s3.amazonaws.com/stardog-logos.public/stardog-logo.png
+maintainers:
+  - name: Stardog Union
+    email: tech@stardog.com
+    url: https://www.stardog.com

--- a/charts/launchpad/templates/_helpers.tpl
+++ b/charts/launchpad/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{- define "launchpad.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "launchpad.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "launchpad" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "imagePullSecret" -}}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.registry (printf "%s:%s" .Values.image.username .Values.image.password | b64enc) | b64enc }}
+{{- end -}}
+
+{{/*
+Return Launchpad namespace to use
+*/}}
+{{- define "launchpad.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/charts/launchpad/templates/secret-image.yaml
+++ b/charts/launchpad/templates/secret-image.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.image.username .Values.image.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-image-pull-secret
+  namespace: {{ include "launchpad.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "launchpad.chart" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" .  }}
+{{- end }}

--- a/charts/launchpad/templates/service.yaml
+++ b/charts/launchpad/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "launchpad.fullname" . }}
+  namespace: {{ include "launchpad.namespace" . }}
+  labels:
+    app: {{ include "launchpad.fullname" . }}
+    helm.sh/chart: {{ include "launchpad.chart" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: {{ .Values.service.port }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  selector:
+    app: {{ include "launchpad.fullname" . }}

--- a/charts/launchpad/templates/statefulset.yaml
+++ b/charts/launchpad/templates/statefulset.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "launchpad.fullname" . }}
+  namespace: {{ include "launchpad.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "launchpad.chart" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: server
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "launchpad.fullname" . }}
+  serviceName: {{ include "launchpad.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "launchpad.fullname" . }}
+        helm.sh/chart: {{ include "launchpad.chart" . }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+        app.kubernetes.io/component: server
+    spec:
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{ if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup  }}
+{{ end }}
+      affinity:
+        podAntiAffinity:
+          {{ .Values.antiAffinity }}:
+        {{- if eq .Values.antiAffinity "requiredDuringSchedulingIgnoredDuringExecution" }}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - {{ include "launchpad.fullname" . }}
+            topologyKey: "kubernetes.io/hostname"
+        {{- else }}
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - {{ include "launchpad.fullname" . }}
+              topologyKey: "kubernetes.io/hostname"
+        {{- end }}
+      containers:
+      - name: {{ include "launchpad.fullname" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        ports:
+        - containerPort: {{ .Values.service.port }}
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: launchpad-data
+          mountPath: /data
+          readOnly: false
+        env:
+        - name: BASE_URL
+          value: "{{ .Values.env.BASE_URL }}"
+        - name: FRIENDLY_NAME
+          value: "{{ .Values.env.FRIENDLY_NAME }}"
+        - name: SECURE
+          value: "{{ .Values.env.SECURE }}"
+        - name: COOKIE_SECRET
+          value: "{{ .Values.env.COOKIE_SECRET }}"
+        - name: AZURE_AUTH_ENABLED
+          value: "{{ .Values.env.AZURE_AUTH_ENABLED }}"
+        - name: AZURE_CLIENT_ID
+          value: "{{ .Values.env.AZURE_CLIENT_ID }}"
+        - name: AZURE_CLIENT_SECRET
+          value: "{{ .Values.env.AZURE_CLIENT_SECRET }}"
+        - name: AZURE_TENANT
+          value: "{{ .Values.env.AZURE_TENANT }}"
+        - name: SSOCONNECTION_CONNECTION1_AZURE_CLIENT_ID
+          value: "{{ .Values.env.SSOCONNECTION_CONNECTION1_AZURE_CLIENT_ID }}"
+        - name: SSOCONNECTION_CONNECTION1_AZURE_CLIENT_SECRET
+          value: "{{ .Values.env.SSOCONNECTION_CONNECTION1_AZURE_CLIENT_SECRET }}"
+        - name: SSOCONNECTION_CONNECTION1_AZURE_TENANT
+          value: "{{ .Values.env.SSOCONNECTION_CONNECTION1_AZURE_TENANT }}"
+        - name: SSOCONNECTION_CONNECTION1_AZURE_STARDOG_ENDPOINT
+          value: "{{ .Values.env.SSOCONNECTION_CONNECTION1_AZURE_STARDOG_ENDPOINT }}"
+        - name: SSOCONNECTION_CONNECTION1_AZURE_DISPLAY_NAME
+          value: "{{ .Values.env.SSOCONNECTION_CONNECTION1_AZURE_DISPLAY_NAME }}"
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- if or (and .Values.image.username .Values.image.password) .Values.image.imagePullSecret }}
+      imagePullSecrets:
+  {{- if and .Values.image.username .Values.image.password }}
+      - name: {{ .Release.Name }}-image-pull-secret
+  {{- end}}
+  {{- if .Values.image.imagePullSecret }}
+      - name: {{ .Values.image.imagePullSecret }}
+  {{- end}}
+{{- end}}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+  volumeClaimTemplates:
+  - metadata:
+      name: launchpad-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]{{ if .Values.persistence.storageClass }}
+      storageClassName: {{ .Values.persistence.storageClass }}{{ end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}

--- a/charts/launchpad/templates/statefulset.yaml
+++ b/charts/launchpad/templates/statefulset.yaml
@@ -72,6 +72,10 @@ spec:
           mountPath: /data
           readOnly: false
         env:
+{{- if .Values.env.DEBUG }}
+        - name: DEBUG
+          value: "{{ .Values.env.DEBUG }}"
+{{- end}}
         - name: BASE_URL
           value: "{{ .Values.env.BASE_URL }}"
         - name: FRIENDLY_NAME

--- a/charts/launchpad/values.yaml
+++ b/charts/launchpad/values.yaml
@@ -37,8 +37,6 @@ tolerations: []
 
 antiAffinity: requiredDuringSchedulingIgnoredDuringExecution
 
-# Stardog should have at least 2 CPUs. The CPU request value is used to set
-# -XX:ActiveProcessorCount=N for the JVM.
 resources:
   requests:
     cpu: 500m
@@ -59,6 +57,9 @@ securityContext:
   fsGroup: 1001
 
 env:
+  # NOTE: remove the DEBUG line once we have CLOUD-3086 (add env var to specify num of gunicorn workers) fixed
+  DEBUG: true
+
   # Basic configuration
   BASE_URL: ""
   FRIENDLY_NAME: "Stardog Applications"

--- a/charts/launchpad/values.yaml
+++ b/charts/launchpad/values.yaml
@@ -1,0 +1,79 @@
+---
+# The namespace for Launchpad resources that override the release namespace
+# namespaceOverride: launchpad
+
+# The number of Launchpad replicas; keep this at 1
+replicaCount: 1
+
+# The service type to use for Launchpad
+service:
+  type: LoadBalancer
+  port: 8080
+  annotations: {}
+  # loadBalancerIP: 0.0.0.0
+
+image:
+  registry: https://registry.hub.docker.com/v2/repositories
+  repository: stardog/launchpad
+# Alternative config to pull from Stardog private repository
+  # registry: https://stardog-stardog-apps.jfrog.io
+  # repository: stardog-stardog-apps.jfrog.io/launchpad
+  tag: v3.0.1
+  pullPolicy: IfNotPresent
+  # username:
+  # password:
+  # imagePullSecret:
+
+# The storage class and size to use for Launchpad data volume
+persistence:
+  storageClass: standard
+  size: 1Gi
+
+nodeSelector: {}
+tolerations: []
+#  - key: key1
+#    value: value1
+#    effect: NoSchedule
+
+antiAffinity: requiredDuringSchedulingIgnoredDuringExecution
+
+# Stardog should have at least 2 CPUs. The CPU request value is used to set
+# -XX:ActiveProcessorCount=N for the JVM.
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: 1
+    memory: 2Gi
+
+
+# these allow you to configure the UID and group ID used by the container when it's running, and the fsGroup sets the group id for the volume-mounts
+securityContext:
+  enabled: false
+  seccompProfile:
+    type: RuntimeDefault
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+
+env:
+  # Basic configuration
+  BASE_URL: ""
+  FRIENDLY_NAME: "Stardog Applications"
+  SECURE: false
+  COOKIE_SECRET: ""
+
+  # Azure Login Provider configuration
+  AZURE_AUTH_ENABLED: true
+  AZURE_CLIENT_ID: ""
+  AZURE_CLIENT_SECRET: ""
+  AZURE_TENANT: "organizations"
+
+  # Azure SSO Connection configuration
+  SSOCONNECTION_CONNECTION1_AZURE_CLIENT_ID: ""
+  SSOCONNECTION_CONNECTION1_AZURE_CLIENT_SECRET: ""
+  SSOCONNECTION_CONNECTION1_AZURE_TENANT: ""
+  SSOCONNECTION_CONNECTION1_AZURE_STARDOG_ENDPOINT: ""
+  SSOCONNECTION_CONNECTION1_AZURE_DISPLAY_NAME: ""


### PR DESCRIPTION
This PR adds a helm chart for Launchpad v3.0. ~and it updates the Stardog helm charts to use update versions of ZooKeeper and the ZK Bitnami chart.~ (UPDATE: removed my changes to the Stardog helm chart; those updates are now in Simon's working branch and [PR](https://github.com/stardog-union/helm-charts/pull/118).)

<hr>

### Testing the Launchpad helm chart

I was able to run and test Launchpad with the following steps:

- Start minikube:
  - `minikube start --driver=docker --kubernetes-version=v1.32.2`
  - `minikube tunnel`
    - Run this in a separate terminal, use Ctrl-C in the terminal to end
    - See [docs](https://minikube.sigs.k8s.io/docs/handbook/accessing/#loadbalancer-access) about supporting the LoadBalancer class in minikube
  - `kubectl version`
  - `kubectl get pods -A`
- Create local-launchpad-values.yaml:
  - `cp charts/launchpad/values.yaml local-launchpad-values.yaml`
  - Edit local-launchpad-values.yaml, setting env vars
- Try a dry-run install:
  - `helm install --debug --dry-run mylaunchpad charts/launchpad -f local-launchpad-values.yaml`
- Run the install:
  - `helm install mylaunchpad charts/launchpad -f local-launchpad-values.yaml`
- Check the install:
  - `kubectl describe pod mylaunchpad-launchpad-0`
  - `kubectl get pods -A`
  - `kubectl get events`
  - `kubectl logs mylaunchpad-launchpad-0`
- Connect to Launchpad:
  - Open your web browser to http://localhost:8080
- Delete the install:
  - `helm delete mylaunchpad`

<hr>

### Testing the Stardog helm chart

I was able to run and test Stardog with the following steps:

- Settings:
  - K8s namespace: stardog-k8s-test
  - Helm release: stardog-helm-test
  - License file: /var/stardog/stardog-license-key.bin
- Start minikube and create the K8s namespace and license secret:
  - `minikube start --driver=docker --kubernetes-version=v1.32.2`
  - `minikube tunnel`
    - Run this in a separate terminal, use Ctrl-C in the terminal to end
    - See [docs](https://minikube.sigs.k8s.io/docs/handbook/accessing/#loadbalancer-access) about supporting the LoadBalancer class in minikube
  - `kubectl version`
  - `kubectl get pods -A`
  - `kubectl create namespace stardog-k8s-test`
  - `kubectl -n stardog-k8s-test create secret generic stardog-license --from-file stardog-license-key.bin=/var/stardog/stardog-license-key.bin`
- Try a dry-run install:
  - `helm install --debug --dry-run stardog-helm-test charts/stardog --namespace stardog-k8s-test --wait --timeout 5m -f ./tests/minikube.yaml --set "cluster.enabled=false" --set "replicaCount=1" --set "zookeeper.enabled=false"`
- Install Stardog as a helm release:
  - `helm install stardog-helm-test charts/stardog --namespace stardog-k8s-test --wait --timeout 5m -f ./tests/minikube.yaml --set "cluster.enabled=false" --set "replicaCount=1" --set "zookeeper.enabled=false"`
- Check the install:
  - `kubectl get pods -A`
  - `kubectl describe pod stardog-helm-test-stardog-0 -n stardog-k8s-test`
  - `kubectl get events -n stardog-k8s-test`
  - `kubectl logs stardog-helm-test-stardog-0 -n stardog-k8s-test`
  - `helm ls --namespace stardog-k8s-test`
- Test the server:
  - `export STARDOG_IP=$(kubectl -n stardog-k8s-test get svc | grep "stardog-helm-test-stardog" | awk '{print $4}')`
  - `stardog-admin --server http://${stardog_ip}:5820/ server status`
- Delete the install:
  - `helm delete stardog-helm-test --namespace stardog-k8s-test`