### PR TITLE
add namespace to license secret creation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Make sure you have a proper stardog license called `stardog-license-key.bin` loc
 ```
 kubectl create secret generic stardog-license --from-file stardog-license-key.bin=stardog-license-key.bin
 ```
+## Replace the Stardog license
+If your license is about to expire, you can replace you existing license with a new one using the following command.
+```
+kubectl -n <your-namespace> create secret generic stardog-license --from-file stardog-license-key.bin=/path/to/new/stardog-license-key.bin --dry-run=client -o yaml | kubectl apply -f -
+```
 
 ## Install Stardog as a helm release
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ kubectl create secret generic stardog-license --from-file stardog-license-key.bi
 ## Replace the Stardog license
 If your license is about to expire, you can replace you existing license with a new one using the following command.
 ```
-kubectl -n <your-namespace> create secret generic stardog-license --from-file stardog-license-key.bin=/path/to/new/stardog-license-key.bin --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n <your-namespace> create secret generic stardog-license --from-file stardog-license-key.bin=/path/to/new/stardog-license-key.bin
 ```
 
 ## Install Stardog as a helm release

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ minikube start --driver=docker --kubernetes-version=v.1.29.0
 ## Set up the Stardog license
 Make sure you have a proper stardog license called `stardog-license-key.bin` located in the root directory of this project.
 ```
-kubectl create secret generic stardog-license --from-file stardog-license-key.bin=stardog-license-key.bin
+kubectl -n <your-namespace> create secret generic stardog-license --from-file stardog-license-key.bin=stardog-license-key.bin
 ```
 ## Replace the Stardog license
 If your license is about to expire, you can replace you existing license with a new one using the following command.


### PR DESCRIPTION
(Ignore the branch name, that was from a PR I did on this repo a couple years ago)

SEW pointed out the license secret generation command doesn't have a namespace, so I added it