### PR TITLE
Feature/cloud 3181 adds ingress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Prerequisites
 - Stardog Cluster license file
 - Helm v3
 - Persistent volume support
-- Load balancer service
+- Load balancer service or Ingress controller
 - Familiarity with Stardog Cluster
 - Familiarity with Apache ZooKeeper
 
@@ -40,6 +40,33 @@ $ kubectl -n <your-namespace> create secret generic stardog-license --from-file 
 $ helm repo add stardog https://stardog-union.github.io/helm-charts/
 $ helm install <helm-release-name> --namespace <your-namespace> stardog/stardog
 ```
+
+### Using Ingress
+
+The charts now support using Ingress for exposing Stardog and Launchpad services. To enable this, you need to have an ingress controller installed, like the [NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/).
+You also need an SSL certificate, and its associated private key to be used by the controller, and you also need to be able
+to point your DNS records to the Ingress object URL once created. Finally, you need to be able to create secrets in the namespace where this is deployed. To find the structure of this secret object, follow https://kubernetes.io/docs/concepts/services-networking/ingress/#tls.
+
+
+Here's an example of how to configure the values needed for ingress to work:
+
+```
+# Ingress configuration for any component. Configure it accordingly for each <compoonent> required, like stardog, or launchpad.
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    # You must own example.com, and you need to be able to point your DNS records to the ingress URL.
+    - host: acme-<component>.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+  - hosts: ["acme-<component>.example.com"]
+    # You need to manually create this secret object
+    secretName: stardog-tls
+```
+
 
 See the Stardog chart's [README](https://github.com/stardog-union/helm-charts/blob/develop/charts/stardog/README.md)
 for a list of configuration parameters.

--- a/charts/launchpad/templates/NOTES.txt
+++ b/charts/launchpad/templates/NOTES.txt
@@ -1,0 +1,21 @@
+Stardog Launchpad
+
+{{- if .Values.ingress.enabled }}
+Your Launchpad instance can be accessed through the Ingress at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+Get the Launchpad URL by running these commands:
+{{- if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "launchpad.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "launchpad.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  echo "Launchpad URL: http://$SERVICE_IP:{{ .Values.service.port }}"
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "launchpad.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Launchpad URL: http://127.0.0.1:{{ .Values.service.port }}"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:$CONTAINER_PORT
+{{- end }}
+{{- end }} 

--- a/charts/launchpad/templates/ingress.yaml
+++ b/charts/launchpad/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "launchpad.fullname" . -}}
+{{- $svcPort := .Values.ports.http -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ include "launchpad.fullname" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }} 

--- a/charts/launchpad/templates/service.yaml
+++ b/charts/launchpad/templates/service.yaml
@@ -17,8 +17,8 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 8080
-    targetPort: {{ .Values.service.port }}
+    port: {{ .Values.ports.http }}
+    targetPort: http
   type: {{ .Values.service.type }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}

--- a/charts/launchpad/templates/statefulset.yaml
+++ b/charts/launchpad/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         ports:
-        - containerPort: {{ .Values.service.port }}
+        - containerPort: {{ .Values.ports.http }}
           name: http
           protocol: TCP
         volumeMounts:
@@ -87,6 +87,8 @@ spec:
           value: "{{ .Values.env.SHARED_USER_PASSWORD }}"
         - name: FRIENDLY_NAME
           value: "{{ .Values.env.FRIENDLY_NAME }}"
+        - name: K8S_DEPLOYMENT
+          value: "{{ .Values.env.K8S_DEPLOYMENT }}"
         - name: SECURE
           value: "{{ .Values.env.SECURE }}"
         - name: COOKIE_SECRET

--- a/charts/launchpad/values.yaml
+++ b/charts/launchpad/values.yaml
@@ -9,6 +9,9 @@ service:
   annotations: {}
   # loadBalancerIP: 0.0.0.0
 
+ingress:
+  enabled: false
+
 image:
   registry: https://registry.hub.docker.com/v2/repositories
   repository: stardog/launchpad

--- a/charts/stardog/templates/NOTES.txt
+++ b/charts/stardog/templates/NOTES.txt
@@ -1,1 +1,21 @@
 Stardog Cluster
+
+{{- if .Values.ingress.enabled }}
+Your Stardog instance can be accessed through the Ingress at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+Get the Stardog URL by running these commands:
+{{- if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "stardog.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "stardog.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  echo "Stardog URL: http://$SERVICE_IP:{{ .Values.ports.server }}"
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "stardog.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Stardog URL: http://127.0.0.1:{{ .Values.ports.server }}"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.ports.server }}:$CONTAINER_PORT
+{{- end }}
+{{- end }}

--- a/charts/stardog/templates/ingress.yaml
+++ b/charts/stardog/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "stardog.fullname" . -}}
+{{- $svcPort := .Values.ports.server -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ include "stardog.fullname" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -41,6 +41,9 @@ service:
   annotations: {}
   # loadBalancerIP: 0.0.0.0
 
+ingress:
+  enabled: false
+
 # The server port is the port to expose the Stardog server
 # The sql port is the port to expose Stardog's business intelligence server
 ports:


### PR DESCRIPTION
the strategy for launchpad and stardog is essentially the same. the only little difference, is that in stardog, the port is defined using `ports.server` and in launchpad using `ports.http`. The reason for this that launchpad is a web application, whereas stardog is an application that happens to be served by an internal http server (which default port is 5820). 
merely a convention thing.