### PR TITLE
Fixes JWT path

### DIFF
--- a/charts/stardog/templates/configmap.yaml
+++ b/charts/stardog/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
     pack.node.join.retry.count=15
     pack.node.join.retry.delay=1m
     {{- if .Values.jwtConfig.enabled }}
-    jwt.conf=/etc/stardog-conf/jwt.yaml
+    jwt.conf=/var/opt/stardog/jwt.yaml
     {{- end }}
 
   {{- .Values.additionalStardogProperties | nindent 4 }}


### PR DESCRIPTION
not sure why i got confused when I introduced this originally, as mount path is clearly /var/opt/stardog. 
This is hard to write tests for, since we need launchpad or some other client to hit the jwt path to determine whether this is working. 
we already have tests for the jwt file existing, so this should be good.

we probably want to parametrize this at some point, but it's a pretty standard location, i don't see any issues.