### PR TITLE
use ECR for ZK (no longer on DH)

### DIFF
--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -165,6 +165,7 @@ zookeeper:
       memory: 2Gi
       cpu: 1
   image:
+    registry: public.ecr.aws
     repository: bitnami/zookeeper
     tag: 3.8.4-debian-12-r17
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Per [here](https://hub.docker.com/r/bitnami/zookeeper):
> [The bitnami/zookeeper image] is no longer available for free through Docker Hub. This image is available as a built OCI artifact in both Debian and Photon base OS formats through a commercial subscription of Bitnami Secure Images. However, there are still other Bitnami Secure Images available as developer editions on Docker Hub. For a complete list of those, [visit the public catalog⁠](https://app-catalog.vmware.com/bitnami/apps) and filter by Availability Type: Trial.

This PR pulls the image from the public ECR mirror.